### PR TITLE
feat: Catch inlined traces, add onlyLocalLeaf option

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
           "type": "string",
           "default": "perf.out",
           "description": "Perf data to search for in project root. Will prompt with finder if file does not exist. Can be a file path (ex: 'perf.output' or 'path/to/perf.txt')."
+        },
+        "perfanno.onlyLocalLeaf": {
+          "type": "boolean",
+          "default": false,
+          "description": "Only show the last trace relative to the current project, not previous parent ones (That don't actually have any self() time). (Re-Read File to apply)"
         }
       }
     }

--- a/src/LineHighlighter.ts
+++ b/src/LineHighlighter.ts
@@ -12,7 +12,7 @@ export namespace LineHighlighter {
 
 	// Apply stored highlights when a text editor is activated
 	export function applyHighlights(editor: vscode.TextEditor): void {
-		const uri = editor.document.uri.fsPath;
+		const uri = editor.document.uri.fsPath.replaceAll("\\", "\\");
 		const highlights = highlightsStore.get(uri);
 		if (highlights) {
 			highlights.forEach(highlight => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,8 +35,8 @@ function strToOutputType(str: string) {
 	}
 }
 
-const config_keys = 		 ['eventOutputType', 'localRelative', 'highlightColor', 'minimumThreshold', 'file'];
-const config_mod_funcs = [ strToOutputType, 	null,            hexToRgb,         null,               null];
+const config_keys = 		 ['eventOutputType', 'localRelative', 'highlightColor', 'minimumThreshold', 'file', 'onlyLocalLeaf'];
+const config_mod_funcs = [ strToOutputType, 	null,            hexToRgb,         null,               null,	null];
 
 function is_affected(event: vscode.ConfigurationChangeEvent): boolean {
 	for (let key of config_keys) {

--- a/src/perfInfo.ts
+++ b/src/perfInfo.ts
@@ -74,7 +74,7 @@ export function perfCallgraphFile(perfDataPath: string): PerfData {
 
 					const funcs = traceLine.split(';');
 					for (const func of funcs) {
-						const funcMatch = func.match(/^(.*?)\s*(\/.*):(\d+)$/);
+						const funcMatch = func.match(/^(.*?)\s+((?:[a-z]:)?\/.+):(\d+)\s*(?:\(inlined\))?$/);
 
 						if (funcMatch) {
 							const [, symbol, file, linenrStr] = funcMatch;
@@ -125,7 +125,7 @@ export function frame_unpack(frame: Frame | string): [string | undefined, string
 	}
 
 	// frame is a string
-	const match = frame.match(/^(.*?)\s*(\/.*):(\d+)$/);
+	const match = frame.match(/^(.*?)\s+((?:[a-z]:)?\/.+):(\d+)\s*(?:\(inlined\))?$/);
 	if (match) {
 		const [, symbol, file, linenrStr] = match;
 		const linenr = parseInt(linenrStr, 10);


### PR DESCRIPTION
Hi! Awesome extension - been very helpful so far.

This PR adds support for traces inlined by the compiler, as was common for me with rust, such as:
<img width="555" height="68" alt="image" src="https://github.com/user-attachments/assets/b872a6d4-94cc-48ab-8386-d05ab34f75d0" />

I also adjusted the regex for parsing lines, to match windows-style paths & match according workspaces.


While testing with my project, I noticed that all traces add descending traces further down the stack to their own, so I added an option to only count the last leaf (actual self-cost) relative to the current workspace.

For example, this function gets highlighted as a major factor (relative the the entrypoint), while in actuality it only adds the costs from its sub-traces further down the stack:
<img width="1200" height="51" alt="image" src="https://github.com/user-attachments/assets/e672aeb7-b4fc-48a9-b834-966f746dd4bf" />

With onlyLocalLeaf on:
<img width="1131" height="46" alt="image" src="https://github.com/user-attachments/assets/9fe09578-14e1-45a8-9d64-f107a3b61125" />

Reference Flame Stack:
<img width="2596" height="370" alt="image" src="https://github.com/user-attachments/assets/d24c1b2b-365b-437b-9066-d1584d1e43a6" />


Im also looking at adding another feature, to show the external functions called on a leaf / trace with a tooltip.