### PR TITLE
Further windows path support for function patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This command will always be the same. Therefore, if desired, one can chain both 
 
 ## Py-Spy Workflow
 
-Perfanno also supports [py-spy](https://github.com/benfred/py-spy) raw output for profiling Python programs. See [https://github.com/MalTeeez/python-perfanno-example/blob/main/tools/perf.sh](https://github.com/MalTeeez/python-perfanno-example/blob/main/tools/perf.sh) for an example script.
+Perfanno also supports [py-spy](https://github.com/benfred/py-spy) raw output for profiling Python programs. See [https://github.com/MalTeeez/python-perfanno-example/blob/main/tools/pyspy.sh](https://github.com/MalTeeez/python-perfanno-example/blob/main/tools/pyspy.sh) for an example script.
 
 1. Profile your Python program with py-spy using the `raw` format and `--full-filenames`:
 

--- a/src/LineHighlighter.ts
+++ b/src/LineHighlighter.ts
@@ -11,7 +11,9 @@ export namespace LineHighlighter {
 
 	// Apply stored highlights when a text editor is activated
 	export function applyHighlights(editor: vscode.TextEditor): void {
-		const uri = editor.document.uri.fsPath.replaceAll("\\", "\\");
+		const uri = editor.document.uri.fsPath
+			.replace(/^[a-z](?=:\\\\)/m, (driveLetter: string) => driveLetter.toUpperCase())
+			.replaceAll("\\\\", "/");
 		const highlights = highlightsStore.get(uri);
 		if (highlights) {
 			highlights.forEach(highlight => {

--- a/src/LineHighlighter.ts
+++ b/src/LineHighlighter.ts
@@ -12,8 +12,8 @@ export namespace LineHighlighter {
 	// Apply stored highlights when a text editor is activated
 	export function applyHighlights(editor: vscode.TextEditor): void {
 		const uri = editor.document.uri.fsPath
-			.replace(/^[a-z](?=:\\\\)/m, (driveLetter: string) => driveLetter.toUpperCase())
-			.replaceAll("\\\\", "/");
+			.replace(/^[a-z](?=:\\)/m, (driveLetter: string) => driveLetter.toUpperCase())
+			.replaceAll("\\", "/");
 		const highlights = highlightsStore.get(uri);
 		if (highlights) {
 			highlights.forEach(highlight => {

--- a/src/perfInfo.ts
+++ b/src/perfInfo.ts
@@ -42,6 +42,10 @@ export interface PerfData {
 	[key: string]: TraceData[];
 }
 
+
+const PERF_FUNCTION_PATTERN = new RegExp(/^(.*?)\s+((?:[a-zA-Z]:)?(?:\/|\\).+):(\d+)\s*(?:\(inlined\))?$/, "m");
+const PYSPY_FUNCTION_PATTERN = new RegExp(/^(.*?)\s+\(((?:[a-zA-Z]:)?(?:\/|\\).+):(\d+)\)$/, "m");
+
 // Reads a perf callgraph file and returns the data.
 //	@param perfDataPath Path to perf callgraph file.
 //	@return Table with the following fields:
@@ -77,7 +81,7 @@ export function perfCallgraphFile(perfDataPath: string): PerfData {
 					const funcs = traceLine.split(';');
 					let lastLocalLeaf;
 					for (const func of funcs) {
-						const funcMatch = func.match(/^(.*?)\s+((?:[a-z]:)?\/.+):(\d+)\s*(?:\(inlined\))?$/);
+						const funcMatch = func.match(PERF_FUNCTION_PATTERN);
 
 						if (funcMatch) {
 							const [, symbol, file, linenrStr] = funcMatch;
@@ -144,7 +148,7 @@ export function pyspyCallgraphFile(pyspyDataPath: string): PerfData {
 				const funcs = traceLine.split(';');
 				let lastLocalLeaf;
 				for (const func of funcs) {
-					const funcMatch = func.match(/^(.*?)\s+\(((?:\/|\\).+):(\d+)\)$/);
+					const funcMatch = func.match(PYSPY_FUNCTION_PATTERN);
 
 					if (funcMatch) {
 						let [, symbol, file, linenrStr] = funcMatch;
@@ -212,7 +216,7 @@ export function frame_unpack(frame: Frame | string): [string | undefined, string
 	}
 
 	// frame is a string
-	const match = frame.match(/^(.*?)\s+((?:[a-z]:)?\/.+):(\d+)\s*(?:\(inlined\))?$/);
+	const match = frame.match(PERF_FUNCTION_PATTERN);
 	if (match) {
 		const [, symbol, file, linenrStr] = match;
 		const linenr = parseInt(linenrStr, 10);

--- a/src/perfInfo.ts
+++ b/src/perfInfo.ts
@@ -190,11 +190,11 @@ export function pyspyCallgraphFile(pyspyDataPath: string): PerfData {
 //        format.
 export function frame_unpack(frame: Frame | string): [string | undefined, string, number | string] {
 	if (typeof frame !== 'string') {
-		if (!frame.file || !frame.linenr) {
+		if (!frame.file || frame.linenr == undefined) {
 			if (!frame.symbol) {
 				throw new Error("frame_unpack: frame must have symbol");
 			}
-			return [undefined, "symbol", frame.symbol];
+			return [frame.symbol, frame.file || "symbol", frame.linenr || 0];
 		}
 
 		if (!realNames[frame.file]) {


### PR DESCRIPTION
With this we add windows path support for pyspy files (cant believe I missed that) and also allow the standard capital path start for perf traces.

This now passes as well for pyspy: 
<img width="690" height="204" alt="image" src="https://github.com/user-attachments/assets/0b548cb0-9ffa-40ea-8f2a-71b1ff50677d" />

While perf now also supports it (after adjusting paths):
<img width="958" height="245" alt="image" src="https://github.com/user-attachments/assets/d0878f5e-59b5-4acf-8c02-ffe8256e3e14" />


I also moved the function patterns into constants so that we don't have to recompile them constantly &  for better organization.
